### PR TITLE
The 'run' script name should be generalized to allow for other interpreters

### DIFF
--- a/build_python_script.py
+++ b/build_python_script.py
@@ -23,7 +23,7 @@ get_nodes_url="%s/Node/get?key=%s&ver=%s&arch=%s&i_count=%s" % (url_base,api,ver
 dat=urllib.urlopen(get_nodes_url).read()
 b=json.loads(dat)
 for h in b['hosts']:
-  cmd="ssh  root@%s 'yum -y install git && git clone %s tests && cd tests && bash -x ./run_tests'" % (h, git_url)
+  cmd="ssh  root@%s 'yum -y install git && git clone %s tests && cd tests && chmod +x ./run_tests && ./run_tests'" % (h, git_url)
   print cmd
   rtn_code=subprocess.call(cmd, shell=True)
   

--- a/build_python_script.py
+++ b/build_python_script.py
@@ -16,13 +16,14 @@ api="ADD YOUR API KEY HERE"
 ver="7"
 arch="x86_64"
 count=1
+git_url="https://example.com/test.git"
 
 get_nodes_url="%s/Node/get?key=%s&ver=%s&arch=%s&i_count=%s" % (url_base,api,ver,arch,count)
 
 dat=urllib.urlopen(get_nodes_url).read()
 b=json.loads(dat)
 for h in b['hosts']:
-  cmd="ssh  root@%s 'yum -y install git && git clone https://<GITURL> tests && cd tests && bash -x ./run.sh'" % h
+  cmd="ssh  root@%s 'yum -y install git && git clone %s tests && cd tests && bash -x ./run_tests'" % (h, git_url)
   print cmd
   rtn_code=subprocess.call(cmd, shell=True)
   


### PR DESCRIPTION
Leaving off the .sh file extension would signify that other interpreters are welcome, and renaming the file to run_tests would allow projects to include that in the root of their upstream project (and not conflict with any other scripts called 'run')
