### PR TITLE
build: Read API key from file

### DIFF
--- a/build_python_script.py
+++ b/build_python_script.py
@@ -12,7 +12,10 @@
 import json, urllib, subprocess, sys
 
 url_base="http://admin.ci.centos.org:8080"
-api="ADD YOUR API KEY HERE"
+
+# This file was generated on your slave.  See https://wiki.centos.org/QaWiki/CI/GettingStarted
+api=open('duffy.key').read().strip()
+
 ver="7"
 arch="x86_64"
 count=1


### PR DESCRIPTION
It's not really super secret, but as CentOS CI gains more users it'd
be good to avoid e.g. compromise of one user making it easy to
compromise other user's CI.
