### PR TITLE
Removed the -q option for qemu-img

### DIFF
--- a/create_looped_disk.sh
+++ b/create_looped_disk.sh
@@ -14,7 +14,7 @@ fname=/var/$(mktemp -u)
 if [ ! -e /usr/bin/qemu-img ]; then
   yum -y -d0 install qemu-img
 fi
-qemu-img create -q -f raw $fname ${size}G
+qemu-img create -f raw $fname ${size}G
 if [ $? -ne 0 ]; then 
   echo 'failed to create host file'
   exit 1


### PR DESCRIPTION
Doesn't work with qemu-img-0.12.1.2-2.491.el6_8.3.x86_64 from CentOS 6
