### PR TITLE
 Add shell version of build_python_script.py 

### DIFF
--- a/build_python_script.py
+++ b/build_python_script.py
@@ -9,28 +9,33 @@
 # Please note, this is a basic script, there is no error handling and there are
 # no real tests for any exceptions. Patches welcome!
 
-import json, urllib, subprocess, sys
+import json
+import urllib
+import subprocess
+import sys
 
-url_base="http://admin.ci.centos.org:8080"
+url_base = "http://admin.ci.centos.org:8080"
 
 # This file was generated on your slave.  See https://wiki.centos.org/QaWiki/CI/GettingStarted
-api=open('duffy.key').read().strip()
+api = open('duffy.key').read().strip()
 
-ver="7"
-arch="x86_64"
-count=1
-git_url="https://example.com/test.git"
+ver = "7"
+arch = "x86_64"
+count = 1
+git_url = "https://example.com/test.git"
 
-get_nodes_url="%s/Node/get?key=%s&ver=%s&arch=%s&count=%s" % (url_base,api,ver,arch,count)
+get_nodes_url = "%s/Node/get?key=%s&ver=%s&arch=%s&count=%s" % (url_base, api, ver, arch, count)
 
-dat=urllib.urlopen(get_nodes_url).read()
-b=json.loads(dat)
+dat = urllib.urlopen(get_nodes_url).read()
+b = json.loads(dat)
 for h in b['hosts']:
-  cmd="ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@%s 'yum -y install git && git clone %s tests && cd tests && chmod +x ./run_tests && ./run_tests'" % (h, git_url)
-  print cmd
-  rtn_code=subprocess.call(cmd, shell=True)
+    cmd = "ssh -t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@%s " \
+          "'yum -y install git && git clone %s tests && cd tests && chmod +x ./run_tests && " \
+          "./run_tests'" % (h, git_url)
+    print(cmd)
+    rtn_code = subprocess.call(cmd, shell=True)
   
-done_nodes_url="%s/Node/done?key=%s&ssid=%s" % (url_base, api, b['ssid'])
-das=urllib.urlopen(done_nodes_url).read()
+done_nodes_url = "%s/Node/done?key=%s&ssid=%s" % (url_base, api, b['ssid'])
+das = urllib.urlopen(done_nodes_url).read()
 
 sys.exit(rtn_code)

--- a/test_shell_script.sh
+++ b/test_shell_script.sh
@@ -1,0 +1,52 @@
+set +e
+
+export CICO_API_KEY=$(cat ~/duffy.key )
+
+# get node
+n=1
+while true
+do
+    cico_output=$(cico node get -f value -c ip_address -c comment)
+    if [ $? -eq 0 ]; then
+        read CICO_hostname CICO_ssid <<< $cico_output
+        if  [ ! -z "$CICO_hostname" ]; then
+            # we got hostname from cico
+            break
+        fi
+        echo "'cico node get' succeed, but can't get hostname from output"
+    fi
+    if [ $n -gt 5 ]; then
+        # give up after 5 tries
+        echo "giving up on 'cico node get'"
+        exit 1
+    fi
+    echo "'cico node get' failed, trying again in 60s ($n/5)"
+    n=$[$n+1]
+    sleep 60
+done
+sshopts="-t -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l root"
+ssh_cmd="ssh $sshopts $CICO_hostname"
+
+$ssh_cmd yum -y install rsync
+
+if [ -n "${ghprbTargetBranch}" ]; then
+    git rebase --preserve-merges origin/${ghprbTargetBranch}
+else
+    echo "Not a PR build, using master"
+fi
+
+rsync -e "ssh $sshopts" -Ha $(pwd)/ $CICO_hostname:payload \
+&& /usr/bin/timeout 30m $ssh_cmd -t "cd payload && make test"
+rtn_code=$?
+if [ $rtn_code -eq 0 ]; then
+    cico node done $CICO_ssid
+else
+    if [[ $rtn_code -eq 124 ]]; then
+       echo "BUILD TIMEOUT";
+       cico node done $CICO_ssid
+    else
+        # fail mode gives us 12 hrs to debug the machine
+        curl "http://admin.ci.centos.org:8080/Node/fail?key=$CICO_API_KEY&ssid=$CICO_ssid"
+    fi
+fi
+exit $rtn_code


### PR DESCRIPTION
Hi,

when I started looking at [Duffy](https://wiki.centos.org/QaWiki/CI/Duffy) & [GettingStarted](https://wiki.centos.org/QaWiki/CI/GettingStarted#head-6ed39ce58614481f837ba710d97dfa01ef4ba818) it first lead me to your python script, which is OK, but most of the jobs actually use `cico` command from a shell script similar to what I'm adding in this PR.